### PR TITLE
[FIT-4752] Fix crash with text editing widget.

### DIFF
--- a/src/wme/im_input_text.cpp
+++ b/src/wme/im_input_text.cpp
@@ -1,5 +1,6 @@
 #include <wme/im_input_text.hpp>
 #include <wme/ptr.hpp>
+#include <algorithm>
 #include <cassert>
 #include <cstring>
 
@@ -31,8 +32,8 @@ auto ImInputText::on_callback(ImGuiInputTextCallbackData& data) -> int {
 }
 
 void ImInputText::resize_buffer(ImGuiInputTextCallbackData& data) {
-	assert(!m_buffer.empty());
-	m_buffer.resize(m_buffer.size() * 2);
+	if (m_buffer.size() >= data.BufSize) { return; }
+	m_buffer.resize(std::max(m_buffer.size() * 2, init_size_v));
 	data.BufSize = static_cast<int>(m_buffer.size());
 	data.Buf = m_buffer.data();
 	data.BufDirty = true;


### PR DESCRIPTION
The previous approach doubled the buffer capacity on the resize callback. But, Dear ImGui calls the resize callback on every key input, so after a lot of inputs the capacity would overflow and cause undefined behavior. The fix uses `BufSize` (set by ImGui before calling the resize callback) to determine whether to resize at all.